### PR TITLE
Add generative property-based fuzzers for grammar parsing and execution

### DIFF
--- a/go/compile_run_fuzz_test.go
+++ b/go/compile_run_fuzz_test.go
@@ -1,0 +1,207 @@
+package langlang
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Generative compile-and-run robustness test — the second step adapted from
+// tommy's algebraic fuzzer (see roundtrip_gen_test.go for the first). Where the
+// round-trip fuzzer exercises the printer/parser, this drives the rest of the
+// pipeline: it generates random *legal, execution-safe* grammars over the PEG
+// expression algebra, compiles each to bytecode (MatcherFromString), and runs
+// the VM over a handful of inputs. The property is robustness, not a specific
+// parse result: the matcher must never panic, must always terminate, and on a
+// successful match must return a well-formed tree (root present, node spans
+// within input bounds, known node types). A clean parse error is an acceptable
+// outcome.
+//
+// Safety: the VM has no step budget and does not guard nullable-body repetition
+// (e* / e+ where e matches empty loops forever). The generator runs in
+// execSafe mode, which only ever repeats a guaranteed-consuming terminal, so no
+// generated grammar can construct that loop. Left recursion is already
+// memoized-safe by the VM. As a belt-and-braces backstop each Match runs under
+// a timeout and a panic recover, so a regression that reintroduces a hang or a
+// crash fails the test (with a reproducer) instead of wedging CI.
+//
+// Determinism: shares the LANGLANG_FUZZ_* knobs with the round-trip fuzzer.
+
+// matchResult captures everything a single Match invocation can produce,
+// including a recovered panic.
+type matchResult struct {
+	tree     Tree
+	consumed int
+	err      error
+	panicked any
+}
+
+// runMatch executes m.Match(input) on a goroutine, converting a panic into a
+// result and bounding wall-clock time. The bool is false if the timeout fired
+// (the matcher did not return in time).
+func runMatch(m Matcher, input []byte, timeout time.Duration) (matchResult, bool) {
+	ch := make(chan matchResult, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ch <- matchResult{panicked: r}
+			}
+		}()
+		tree, n, err := m.Match(input)
+		ch <- matchResult{tree: tree, consumed: n, err: err}
+	}()
+	select {
+	case res := <-ch:
+		return res, true
+	case <-time.After(timeout):
+		return matchResult{}, false
+	}
+}
+
+// checkTree asserts the structural invariants of a successful match: the
+// consumed count is within bounds and, when a tree was produced, every node has
+// a known type and a span contained in the input with Start <= End (Text() must
+// not panic). A successful match may legitimately have no root — e.g. when the
+// matching alternative is a lookahead predicate (&e / !e) or matches empty, the
+// VM consumes nothing and captures nothing.
+func checkTree(t *testing.T, res matchResult, src string, input []byte) {
+	t.Helper()
+	require.GreaterOrEqualf(t, res.consumed, 0, "negative consumed count %d\ngrammar:\n%s\ninput: %q", res.consumed, src, input)
+	require.LessOrEqualf(t, res.consumed, len(input), "consumed %d > input len %d\ngrammar:\n%s\ninput: %q", res.consumed, len(input), src, input)
+
+	root, ok := res.tree.Root()
+	if !ok {
+		return
+	}
+	res.tree.Visit(root, func(id NodeID) bool {
+		ty := res.tree.Type(id)
+		require.LessOrEqualf(t, ty, NodeType_Error, "unknown node type %d\ngrammar:\n%s\ninput: %q", ty, src, input)
+		sp := res.tree.Span(id)
+		require.GreaterOrEqualf(t, sp.Start.Cursor, 0, "node span start %d < 0\ngrammar:\n%s\ninput: %q", sp.Start.Cursor, src, input)
+		require.LessOrEqualf(t, sp.End.Cursor, len(input), "node span end %d > input len %d\ngrammar:\n%s\ninput: %q", sp.End.Cursor, len(input), src, input)
+		require.LessOrEqualf(t, sp.Start.Cursor, sp.End.Cursor, "node span start %d > end %d\ngrammar:\n%s\ninput: %q", sp.Start.Cursor, sp.End.Cursor, src, input)
+		_ = res.tree.Text(id) // must not panic
+		return true
+	})
+}
+
+// collectTerminals gathers the literal strings and the left endpoint of each
+// range used anywhere in the grammar, so inputsFor can bias inputs toward
+// characters the grammar actually mentions. It only walks the node types the
+// generator produces.
+func collectTerminals(node AstNode) (lits []string, chars []rune) {
+	var walk func(AstNode)
+	walk = func(n AstNode) {
+		switch x := n.(type) {
+		case *GrammarNode:
+			for _, d := range x.Definitions {
+				walk(d)
+			}
+		case *DefinitionNode:
+			walk(x.Expr)
+		case *ChoiceNode:
+			walk(x.Left)
+			walk(x.Right)
+		case *SequenceNode:
+			for _, it := range x.Items {
+				walk(it)
+			}
+		case *OptionalNode:
+			walk(x.Expr)
+		case *ZeroOrMoreNode:
+			walk(x.Expr)
+		case *OneOrMoreNode:
+			walk(x.Expr)
+		case *NotNode:
+			walk(x.Expr)
+		case *AndNode:
+			walk(x.Expr)
+		case *LexNode:
+			walk(x.Expr)
+		case *ClassNode:
+			for _, it := range x.Items {
+				walk(it)
+			}
+		case *RangeNode:
+			chars = append(chars, x.Left)
+		case *LiteralNode:
+			lits = append(lits, x.Value)
+		}
+	}
+	walk(node)
+	return
+}
+
+// inputsFor builds n candidate inputs for a grammar: the empty string, one
+// "designed" string concatenating a few of the grammar's own literals (to bias
+// toward a match), and random alphanumeric strings (bounded length, to keep the
+// unmemoized PEG runtime well clear of exponential blow-up) drawn from an
+// alphabet that includes the grammar's class characters.
+func (g *shapeGen) inputsFor(grammar *GrammarNode, n int) [][]byte {
+	lits, chars := collectTerminals(grammar)
+	alpha := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	for _, ch := range chars {
+		if ch < 128 {
+			alpha = append(alpha, byte(ch))
+		}
+	}
+
+	out := [][]byte{[]byte("")}
+	if len(lits) > 0 {
+		var b strings.Builder
+		for i := 0; i < 3; i++ {
+			b.WriteString(lits[g.rng.Intn(len(lits))])
+		}
+		out = append(out, []byte(b.String()))
+	}
+	for len(out) < n {
+		buf := make([]byte, g.rng.Intn(9)) // 0..8 bytes
+		for i := range buf {
+			buf[i] = alpha[g.rng.Intn(len(alpha))]
+		}
+		out = append(out, buf)
+	}
+	return out
+}
+
+func TestCompileRunFuzz(t *testing.T) {
+	seed := fuzzEnvInt("LANGLANG_FUZZ_SEED", 1)
+	cases := fuzzEnvInt("LANGLANG_FUZZ_CASES", 200)
+	maxDefs := fuzzEnvInt("LANGLANG_FUZZ_MAXDEFS", 4)
+	depth := fuzzEnvInt("LANGLANG_FUZZ_DEPTH", 4)
+
+	rng := rand.New(rand.NewSource(int64(seed)))
+	compiled := 0
+	for c := 0; c < cases; c++ {
+		t.Run(fmt.Sprintf("case-%d", c), func(t *testing.T) {
+			g := &shapeGen{rng: rng, numDefs: 1 + rng.Intn(maxDefs), execSafe: true}
+			grammar := g.genGrammar(depth)
+			src := grammar.String()
+
+			m, err := MatcherFromString(src)
+			if err != nil {
+				// A legal-to-parse grammar that fails to *compile* is allowed
+				// (e.g. a semantic rejection); log it for visibility but do not
+				// fail. The compiled-count assertion below guards against the
+				// whole pipeline silently breaking.
+				t.Logf("compile error (skipping run) for grammar:\n%s\nerr: %v", src, err)
+				return
+			}
+			compiled++
+
+			for _, input := range g.inputsFor(grammar, 6) {
+				res, done := runMatch(m, input, 2*time.Second)
+				require.Truef(t, done, "Match did not terminate within timeout\ngrammar:\n%s\ninput: %q", src, input)
+				require.Nilf(t, res.panicked, "Match panicked: %v\ngrammar:\n%s\ninput: %q", res.panicked, src, input)
+				if res.err == nil {
+					checkTree(t, res, src, input)
+				}
+			}
+		})
+	}
+	require.Positivef(t, compiled, "no generated grammar compiled across %d cases — generator or pipeline regression", cases)
+}

--- a/go/matching_input_fuzz_test.go
+++ b/go/matching_input_fuzz_test.go
@@ -1,0 +1,117 @@
+package langlang
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Matching-input fuzzer — the deepest step, and the true dual of tommy's
+// algebraic fuzzer. tommy's TestRoundTripFuzz generates a random *type* and a
+// *value inhabiting it*, then asserts decode(encode(value)) == value. The PEG
+// analog is to generate a random *grammar* and a *string in its language*, then
+// assert the matcher accepts it. The previous fuzzers only ever fed the matcher
+// arbitrary inputs (most rejected); this one feeds it inputs that are
+// constructed to be in the grammar, exercising the accept path end-to-end.
+//
+// Soundness — the hard part. A string is guaranteed in the language only if it
+// follows PEG's deterministic matching. The generator (execSafe + noRepetition
+// + noPredicate) restricts grammars to the star-free, predicate-free subset
+// where every construct consumes a bounded, exactly-known amount, so a string
+// co-generated from the grammar matches and fully consumes deterministically:
+//   - atom (Literal/Class/Any): consumes exactly its one sample.
+//   - sequence: the concatenation of its items' samples.
+//   - choice: the FIRST branch's sample — PEG tries the first branch first and
+//     commits when it matches, so first-branch strings always take that path.
+//   - optional e?: emit e's sample (never empty). `?` is greedy, so it consumes
+//     the present match; emitting empty would let `?` eat a following overlap.
+//   - lex #e: e's sample (lex only toggles auto-spacing, which is moot with
+//     space-free samples).
+// Excluded (unsound to co-generate without first-set/context coordination):
+//   - * / + : unbounded-greedy, eat into a following sibling on overlap
+//     (`[a-z]* 'm'` rejects "am"); and & / ! : couple to the following context.
+// Empirically this subset is exact — across thousands of generated grammars
+// every co-generated string both matched and consumed the whole input — so the
+// acceptance and full-consumption checks below are hard assertions.
+//
+// Determinism: shares the LANGLANG_FUZZ_* knobs with the other fuzzers.
+
+// sampleString co-generates a string in the language of n, recursing through
+// rule references (acyclic in execSafe mode, so this terminates).
+func sampleString(n AstNode, defs map[string]*DefinitionNode) string {
+	switch x := n.(type) {
+	case *AnyNode:
+		return "a" // any single byte matches "."
+	case *LiteralNode:
+		return x.Value
+	case *ClassNode:
+		// The left endpoint of the first range is guaranteed inside the class.
+		if len(x.Items) > 0 {
+			if rg, ok := x.Items[0].(*RangeNode); ok {
+				return string(rg.Left)
+			}
+		}
+		return "a"
+	case *IdentifierNode:
+		return sampleString(defs[x.Value].Expr, defs)
+	case *OptionalNode:
+		return sampleString(x.Expr, defs)
+	case *LexNode:
+		return sampleString(x.Expr, defs)
+	case *SequenceNode:
+		var b strings.Builder
+		for _, it := range x.Items {
+			b.WriteString(sampleString(it, defs))
+		}
+		return b.String()
+	case *ChoiceNode:
+		return sampleString(x.Left, defs)
+	default:
+		// * / + / & / ! are excluded from the co-generatable subset.
+		panic(fmt.Sprintf("sampleString: unexpected node %T in co-generatable grammar", n))
+	}
+}
+
+func TestMatchingInputFuzz(t *testing.T) {
+	seed := fuzzEnvInt("LANGLANG_FUZZ_SEED", 1)
+	cases := fuzzEnvInt("LANGLANG_FUZZ_CASES", 200)
+	maxDefs := fuzzEnvInt("LANGLANG_FUZZ_MAXDEFS", 4)
+	depth := fuzzEnvInt("LANGLANG_FUZZ_DEPTH", 4)
+
+	rng := rand.New(rand.NewSource(int64(seed)))
+	matched := 0
+	for c := 0; c < cases; c++ {
+		t.Run(fmt.Sprintf("case-%d", c), func(t *testing.T) {
+			g := &shapeGen{
+				rng:          rng,
+				numDefs:      1 + rng.Intn(maxDefs),
+				execSafe:     true,
+				noRepetition: true,
+				noPredicate:  true,
+			}
+			grammar := g.genGrammar(depth)
+			src := grammar.String()
+
+			m, err := MatcherFromString(src)
+			if err != nil {
+				t.Logf("grammar did not compile (skipping) for:\n%s\nerr: %v", src, err)
+				return
+			}
+
+			input := []byte(sampleString(grammar.Definitions[0].Expr, grammar.DefsByName))
+			res, done := runMatch(m, input, 2*time.Second)
+			require.Truef(t, done, "Match did not terminate\ngrammar:\n%s\ninput: %q", src, input)
+			require.Nilf(t, res.panicked, "Match panicked: %v\ngrammar:\n%s\ninput: %q", res.panicked, src, input)
+
+			require.NoErrorf(t, res.err, "co-generated in-language string was REJECTED\ngrammar:\n%s\ninput: %q", src, input)
+			require.Equalf(t, len(input), res.consumed, "in-language string matched but did not fully consume (%d of %d bytes)\ngrammar:\n%s\ninput: %q", res.consumed, len(input), src, input)
+			checkTree(t, res, src, input)
+			matched++
+		})
+	}
+	require.Positivef(t, matched, "no generated grammar produced a matched in-language string across %d cases", cases)
+}

--- a/go/roundtrip_gen_test.go
+++ b/go/roundtrip_gen_test.go
@@ -64,6 +64,16 @@ type shapeGen struct {
 	// curDef is the index of the definition currently being generated; used in
 	// exec-safe mode to keep references strictly forward (acyclic).
 	curDef int
+
+	// noRepetition and noPredicate further restrict generation to the
+	// star-free, predicate-free subset that the matching-input fuzzer can
+	// co-generate a guaranteed in-language string for: every construct then
+	// consumes a bounded, exactly-known amount (atoms, sequence, choice,
+	// optional, lex), so a derived string matches and fully consumes
+	// deterministically. * / + are unbounded-greedy and & / ! couple to the
+	// following context, so both are excluded there. Independent of execSafe.
+	noRepetition bool
+	noPredicate  bool
 }
 
 func (g *shapeGen) ruleName(i int) string { return "R" + strconv.Itoa(i) }
@@ -139,6 +149,9 @@ func (g *shapeGen) genSuffixed(depth int) AstNode {
 	if depth <= 0 || g.rng.Intn(2) == 1 {
 		return prim
 	}
+	if g.noRepetition {
+		return NewOptionalNode(prim, fuzzLoc)
+	}
 	switch g.rng.Intn(3) {
 	case 0:
 		return NewOptionalNode(prim, fuzzLoc)
@@ -185,6 +198,9 @@ func (g *shapeGen) genItem(depth int) AstNode {
 	inner := g.genSuffixed(depth)
 	if depth <= 0 || g.rng.Intn(3) != 0 {
 		return inner
+	}
+	if g.noPredicate {
+		return NewLexNode(inner, fuzzLoc) // lex is consumption-neutral; & / ! are not
 	}
 	switch g.rng.Intn(3) {
 	case 0:

--- a/go/roundtrip_gen_test.go
+++ b/go/roundtrip_gen_test.go
@@ -47,6 +47,23 @@ var fuzzLoc = SourceLocation{}
 type shapeGen struct {
 	rng     *rand.Rand
 	numDefs int
+
+	// execSafe restricts generation to grammars that are safe to *run* on the
+	// step-budget-less VM. Two hazards are excluded by construction:
+	//   - Nullable-body repetition (e* / e+ where e matches empty) loops
+	//     forever, so a repetition operand is never a rule reference (whose
+	//     nullability needs whole-grammar analysis), only a consuming terminal.
+	//   - Recursion is dropped entirely: references point strictly forward
+	//     (R_i -> R_j, j > i), so the rule graph is acyclic. This rules out
+	//     direct/mutual left recursion *and* recursion through a & / ! predicate
+	//     — the latter is not caught by the VM's left-recursion memoization and
+	//     recurses unboundedly (e.g. `R0 <- 'b' / &R0 . .` on "").
+	// Off by default so the round-trip fuzzer's RNG stream is unchanged.
+	execSafe bool
+
+	// curDef is the index of the definition currently being generated; used in
+	// exec-safe mode to keep references strictly forward (acyclic).
+	curDef int
 }
 
 func (g *shapeGen) ruleName(i int) string { return "R" + strconv.Itoa(i) }
@@ -95,8 +112,23 @@ func (g *shapeGen) genPrimary() AstNode {
 	case 2:
 		return g.genClass()
 	default:
+		return g.genReference()
+	}
+}
+
+// genReference emits a non-terminal (rule) reference. In the default mode it
+// may point at any rule (self/backward refs are valid round-trip fodder). In
+// exec-safe mode it points strictly forward to keep the rule graph acyclic; the
+// last rule has no forward target, so it degenerates to a terminal.
+func (g *shapeGen) genReference() AstNode {
+	if !g.execSafe {
 		return NewIdentifierNode(g.ruleName(g.rng.Intn(g.numDefs)), fuzzLoc)
 	}
+	lo := g.curDef + 1
+	if lo >= g.numDefs {
+		return g.genTerminal()
+	}
+	return NewIdentifierNode(g.ruleName(lo+g.rng.Intn(g.numDefs-lo)), fuzzLoc)
 }
 
 // genSuffixed optionally wraps a primary in one suffix operator. The parser
@@ -111,10 +143,39 @@ func (g *shapeGen) genSuffixed(depth int) AstNode {
 	case 0:
 		return NewOptionalNode(prim, fuzzLoc)
 	case 1:
-		return NewZeroOrMoreNode(prim, fuzzLoc)
+		return NewZeroOrMoreNode(g.repeatable(prim), fuzzLoc)
 	default:
-		return NewOneOrMoreNode(prim, fuzzLoc)
+		return NewOneOrMoreNode(g.repeatable(prim), fuzzLoc)
 	}
+}
+
+// genTerminal emits a guaranteed-consuming atom (never a rule reference): any
+// (.), a non-empty literal, or a character class. Each matches at least one
+// byte, so repeating it cannot loop.
+func (g *shapeGen) genTerminal() AstNode {
+	switch g.rng.Intn(3) {
+	case 0:
+		return NewAnyNode(fuzzLoc)
+	case 1:
+		return NewLiteralNode(g.literalText(), fuzzLoc)
+	default:
+		return g.genClass()
+	}
+}
+
+// repeatable returns prim unchanged, except in exec-safe mode where a rule
+// reference (whose nullability is unknown without whole-grammar analysis) is
+// swapped for a non-nullable terminal so that wrapping it in * / + can never
+// produce a nullable-body infinite loop. In the default (round-trip) mode it is
+// a no-op and draws no randomness, leaving that RNG stream untouched.
+func (g *shapeGen) repeatable(prim AstNode) AstNode {
+	if !g.execSafe {
+		return prim
+	}
+	if _, ok := prim.(*IdentifierNode); ok {
+		return g.genTerminal()
+	}
+	return prim
 }
 
 // genItem produces one sequence element: a suffixed primary, optionally with a
@@ -174,6 +235,7 @@ func (g *shapeGen) genGrammar(depth int) *GrammarNode {
 	defs := make([]*DefinitionNode, g.numDefs)
 	byName := map[string]*DefinitionNode{}
 	for i := range defs {
+		g.curDef = i
 		name := g.ruleName(i)
 		def := NewDefinitionNode(name, g.genExpression(depth), fuzzLoc)
 		defs[i] = def

--- a/go/roundtrip_gen_test.go
+++ b/go/roundtrip_gen_test.go
@@ -1,0 +1,223 @@
+package langlang
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Generative round-trip property test, adapted from tommy's algebraic fuzzer
+// (generate/roundtrip_gen_test.go). Where tommy generates random *legal* nested
+// type shapes over its Scalar/Ptr/Slice/Map/Struct type algebra and asserts
+// decode(encode(v)) == v, this generates random *legal* grammar ASTs over
+// langlang's PEG expression algebra (grammar_ast.go) and asserts
+// parse(g.String()) == g — i.e. the AST printer and the (bootstrapped) grammar
+// parser round-trip. It catches printer/parser drift in CI rather than in a
+// downstream migration.
+//
+// Scope: the structural core of the algebra — Choice / Sequence, the prefix
+// operators (! & #), the suffix operators (? * +), and the atoms (rule
+// reference, Literal, Any, and a character Class of ranges). Generation is
+// indexed by PEG operator precedence (Choice > Sequence > Prefix > Suffix >
+// Primary) so that String() is unambiguous. The AST→text printer emits no
+// parentheses, so any shape that would *need* grouping to round-trip is
+// deliberately not produced — the analog of tommy's fuzzer excluding the
+// text/custom codecs and cross-package delegation, which live elsewhere.
+//
+// Out of scope for the same printer/round-trip reasons (left for a follow-up,
+// e.g. a compile→VM property or a grouping-aware printer): parenthesized
+// grouping, Labeled/Capture/Precedence, NameBinding/BytesConsume/
+// CountedRepetition, NumericPrimitive, Import, and the post-parse Charset form.
+//
+// Determinism: a fixed seed (override LANGLANG_FUZZ_SEED) and case count
+// (LANGLANG_FUZZ_CASES) so CI runs the same shapes every time and failures
+// reproduce. On failure the generated grammar source is printed.
+
+// fuzzLoc is the source location stamped on every generated node. AstNode.Equal
+// ignores source positions, so a zero value is fine — only structure matters.
+var fuzzLoc = SourceLocation{}
+
+// shapeGen carries the per-grammar generation state: the seeded RNG and the
+// number of rules in scope (R0..R{numDefs-1}), so a primary can emit a
+// reference to any defined rule.
+type shapeGen struct {
+	rng     *rand.Rand
+	numDefs int
+}
+
+func (g *shapeGen) ruleName(i int) string { return "R" + strconv.Itoa(i) }
+
+// literalText builds a single-quoted-literal body restricted to characters that
+// survive LiteralNode.String() (which quotes raw, without escaping): lowercase
+// letters and digits, never a quote or backslash.
+func (g *shapeGen) literalText() string {
+	const alpha = "abcdefghijklmnopqrstuvwxyz0123456789"
+	n := 1 + g.rng.Intn(3) // 1..3 chars
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alpha[g.rng.Intn(len(alpha))]
+	}
+	return string(b)
+}
+
+// genClass builds a [..] character class of 1..3 ranges drawn from a single
+// alphabet block, so RangeNode.String() ("a-z") reparses cleanly. We emit only
+// ranges (never bare single chars): a single char inside a class round-trips to
+// a LiteralNode, whose String() re-quotes it ('x') and breaks the class form.
+func (g *shapeGen) genClass() AstNode {
+	blocks := [][2]rune{{'a', 'z'}, {'A', 'Z'}, {'0', '9'}}
+	n := 1 + g.rng.Intn(3)
+	items := make([]AstNode, n)
+	for i := range items {
+		blk := blocks[g.rng.Intn(len(blocks))]
+		span := int(blk[1] - blk[0])
+		lo := blk[0] + rune(g.rng.Intn(span+1))
+		hi := lo + rune(g.rng.Intn(int(blk[1]-lo)+1))
+		items[i] = NewRangeNode(lo, hi, fuzzLoc)
+	}
+	return NewClassNode(items, fuzzLoc)
+}
+
+// genPrimary emits an atom: a rule reference, a literal, any (.), or a class.
+// Atoms never recurse into a sub-expression — without printable parentheses a
+// grouped expression cannot round-trip — so the algebra here is intentionally
+// flat below the suffix level.
+func (g *shapeGen) genPrimary() AstNode {
+	switch g.rng.Intn(4) {
+	case 0:
+		return NewAnyNode(fuzzLoc)
+	case 1:
+		return NewLiteralNode(g.literalText(), fuzzLoc)
+	case 2:
+		return g.genClass()
+	default:
+		return NewIdentifierNode(g.ruleName(g.rng.Intn(g.numDefs)), fuzzLoc)
+	}
+}
+
+// genSuffixed optionally wraps a primary in one suffix operator. The parser
+// allows a single suffix on a primary (Primary ("?"/"*"/"+")?), so we never
+// stack them.
+func (g *shapeGen) genSuffixed(depth int) AstNode {
+	prim := g.genPrimary()
+	if depth <= 0 || g.rng.Intn(2) == 1 {
+		return prim
+	}
+	switch g.rng.Intn(3) {
+	case 0:
+		return NewOptionalNode(prim, fuzzLoc)
+	case 1:
+		return NewZeroOrMoreNode(prim, fuzzLoc)
+	default:
+		return NewOneOrMoreNode(prim, fuzzLoc)
+	}
+}
+
+// genItem produces one sequence element: a suffixed primary, optionally with a
+// prefix operator (! & #) applied. A prefix binds tighter than sequence, so
+// "!a b" is (!a) b — exactly how genItem nests it.
+func (g *shapeGen) genItem(depth int) AstNode {
+	inner := g.genSuffixed(depth)
+	if depth <= 0 || g.rng.Intn(3) != 0 {
+		return inner
+	}
+	switch g.rng.Intn(3) {
+	case 0:
+		return NewNotNode(inner, fuzzLoc)
+	case 1:
+		return NewAndNode(inner, fuzzLoc)
+	default:
+		return NewLexNode(inner, fuzzLoc)
+	}
+}
+
+// genSequence builds a 1..3 element SequenceNode. The parser always wraps a
+// choice branch in a Sequence (even a single element), so we mirror that shape
+// for structural equality.
+func (g *shapeGen) genSequence(depth int) AstNode {
+	n := 1
+	if depth > 0 {
+		n = 1 + g.rng.Intn(3)
+	}
+	items := make([]AstNode, n)
+	for i := range items {
+		items[i] = g.genItem(depth - 1)
+	}
+	return NewSequenceNode(items, fuzzLoc)
+}
+
+// genExpression builds 1..3 sequence alternatives folded into a
+// right-associative Choice, matching parseChoice's fold (a / b / c parses as
+// Choice(a, Choice(b, c))).
+func (g *shapeGen) genExpression(depth int) AstNode {
+	alts := 1
+	if depth > 0 {
+		alts = 1 + g.rng.Intn(3)
+	}
+	accum := g.genSequence(depth - 1)
+	branches := make([]AstNode, alts-1)
+	for i := range branches {
+		branches[i] = g.genSequence(depth - 1)
+	}
+	for i := len(branches) - 1; i >= 0; i-- {
+		accum = NewChoiceNode(branches[i], accum, fuzzLoc)
+	}
+	return accum
+}
+
+// genGrammar emits numDefs definitions named R0..R{numDefs-1}.
+func (g *shapeGen) genGrammar(depth int) *GrammarNode {
+	defs := make([]*DefinitionNode, g.numDefs)
+	byName := map[string]*DefinitionNode{}
+	for i := range defs {
+		name := g.ruleName(i)
+		def := NewDefinitionNode(name, g.genExpression(depth), fuzzLoc)
+		defs[i] = def
+		byName[name] = def
+	}
+	return NewGrammarNode(nil, defs, byName, fuzzLoc)
+}
+
+func fuzzEnvInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func TestRoundTripFuzz(t *testing.T) {
+	seed := fuzzEnvInt("LANGLANG_FUZZ_SEED", 1)
+	cases := fuzzEnvInt("LANGLANG_FUZZ_CASES", 200)
+	maxDefs := fuzzEnvInt("LANGLANG_FUZZ_MAXDEFS", 4)
+	depth := fuzzEnvInt("LANGLANG_FUZZ_DEPTH", 4)
+
+	rng := rand.New(rand.NewSource(int64(seed)))
+	for c := 0; c < cases; c++ {
+		t.Run(fmt.Sprintf("case-%d", c), func(t *testing.T) {
+			g := &shapeGen{rng: rng, numDefs: 1 + rng.Intn(maxDefs)}
+			want := g.genGrammar(depth)
+			src := want.String()
+
+			got, err := NewGrammarParser([]byte(src)).Parse()
+			require.NoErrorf(t, err, "parse failed for:\n%s", src)
+
+			gn, ok := got.(*GrammarNode)
+			require.Truef(t, ok, "parse returned %T, not *GrammarNode, for:\n%s", got, src)
+			require.Emptyf(t, gn.Errors, "parse produced errors for:\n%s\nerrors: %v", src, gn.Errors)
+
+			if !want.Equal(gn) {
+				t.Fatalf("round-trip structural mismatch\n--- source ---\n%s\n--- reparsed ---\n%s", src, gn.String())
+			}
+			// Print idempotence: re-printing the reparsed AST must be byte-identical.
+			if got2 := gn.String(); got2 != src {
+				t.Fatalf("print not idempotent\n--- first ---\n%s\n--- second ---\n%s", src, got2)
+			}
+		})
+	}
+}

--- a/go/spelling_fuzz_test.go
+++ b/go/spelling_fuzz_test.go
@@ -1,0 +1,244 @@
+package langlang
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Spelling-equivalence fuzzer — the langlang adaptation of tommy's spelling
+// fuzzer (#107, generate/roundtrip_spelling_test.go). tommy's observation: its
+// round-trip fuzzers only ever feed the decoder ONE canonical spelling (the
+// encoder's own output), so the other valid TOML spellings of the same value
+// (inline tables vs sub-tables, dotted keys vs nested tables, ...) go untested;
+// #107 re-spells the canonical encoding and checks each spelling decodes the
+// same.
+//
+// The PEG parallel is exact, and it closes the gap the round-trip fuzzer
+// (roundtrip_gen_test.go) left open: the AST printer (String()) emits no
+// parentheses, so grouping cannot be tested via a *syntactic* round-trip. A PEG
+// expression has multiple equivalent *surface spellings* — `a b c` and
+// `(a b) c`, `a/b/c` and `(a/b)/c`, `e+` and `e e*` — that must compile and
+// parse identically. So this fuzzer generates a canonical grammar, re-spells it,
+// and asserts the spellings agree behaviourally (accept + bytes consumed) on a
+// set of inputs. That is a *semantic*-equivalence property, testing exactly what
+// the round-trip fuzzer could not.
+//
+// Classification mirrors tommy's, with hardness per variant:
+//   - parenthesized (HARD): grouping is semantically transparent in langlang's
+//     parser (a parenthesized expression is just a primary), so a disagreement
+//     is a real bug and fails CI.
+//   - plus-desugared (SOFT): `e+` == `e e*` holds for the recognized language,
+//     but the rewrite is applied to the AST and rendered through the canonical
+//     String() printer, which emits no parentheses. When the `+` sits under a
+//     prefix/suffix operator (e.g. `&.+`), the desugared sequence loses its
+//     grouping on the way to text (`&. .*` reparses as `(&.) .*`), so the
+//     spelling diverges. That is logged as xfail (never fails CI) — the staged
+//     "fuzzer-first" stance tommy takes for spellings not yet guaranteed — and
+//     it re-demonstrates, from another angle, the printer grouping-loss that
+//     motivates the parenthesized variant.
+//
+// A coverage guard requires that the rewrites actually changed the source (so
+// the fuzzer is not silently comparing canonical against canonical).
+//
+// Reuses the execSafe shape generator and the compile/run helpers from
+// roundtrip_gen_test.go and compile_run_fuzz_test.go, and shares the
+// LANGLANG_FUZZ_* knobs.
+
+// grammarSpelling is one semantics-preserving rewrite, paired with a serializer
+// that renders the (re-spelled) grammar source from the canonical AST.
+type grammarSpelling struct {
+	name  string
+	hard  bool // hard: a behavioural disagreement fails CI; soft: logged xfail
+	spell func(*GrammarNode) string
+}
+
+var grammarSpellings = []grammarSpelling{
+	{"parenthesized", true, spellParenthesized},
+	{"plus-desugared", false, spellPlusDesugared},
+}
+
+// parenExpr renders an expression with every composite sub-expression wrapped in
+// explicit parentheses. Atoms are bare; sequences, choices, and the operands of
+// the prefix/suffix operators are grouped. Grouping is transparent to langlang's
+// parser, so the result denotes the same language as the bare form.
+func parenExpr(n AstNode) string {
+	switch x := n.(type) {
+	case *OptionalNode:
+		return "(" + parenExpr(x.Expr) + ")?"
+	case *ZeroOrMoreNode:
+		return "(" + parenExpr(x.Expr) + ")*"
+	case *OneOrMoreNode:
+		return "(" + parenExpr(x.Expr) + ")+"
+	case *NotNode:
+		return "!(" + parenExpr(x.Expr) + ")"
+	case *AndNode:
+		return "&(" + parenExpr(x.Expr) + ")"
+	case *LexNode:
+		return "#(" + parenExpr(x.Expr) + ")"
+	case *SequenceNode:
+		parts := make([]string, len(x.Items))
+		for i, it := range x.Items {
+			parts[i] = parenExpr(it)
+		}
+		return "(" + strings.Join(parts, " ") + ")"
+	case *ChoiceNode:
+		return "(" + parenExpr(x.Left) + " / " + parenExpr(x.Right) + ")"
+	default: // *AnyNode, *LiteralNode, *IdentifierNode, *ClassNode
+		return n.String()
+	}
+}
+
+func spellParenthesized(g *GrammarNode) string {
+	var b strings.Builder
+	for i, d := range g.Definitions {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(d.Name)
+		b.WriteString(" <- ")
+		b.WriteString(parenExpr(d.Expr))
+	}
+	return b.String()
+}
+
+// desugarPlus rewrites every `e+` to `e e*`, leaving the rest of the AST
+// structurally identical. In execSafe mode `+` only wraps a (consuming)
+// terminal, so duplicating the operand is side-effect-free.
+func desugarPlus(n AstNode) AstNode {
+	switch x := n.(type) {
+	case *GrammarNode:
+		defs := make([]*DefinitionNode, len(x.Definitions))
+		byName := map[string]*DefinitionNode{}
+		for i, d := range x.Definitions {
+			nd := desugarPlus(d).(*DefinitionNode)
+			defs[i] = nd
+			byName[nd.Name] = nd
+		}
+		return NewGrammarNode(nil, defs, byName, fuzzLoc)
+	case *DefinitionNode:
+		return NewDefinitionNode(x.Name, desugarPlus(x.Expr), fuzzLoc)
+	case *ChoiceNode:
+		return NewChoiceNode(desugarPlus(x.Left), desugarPlus(x.Right), fuzzLoc)
+	case *SequenceNode:
+		items := make([]AstNode, len(x.Items))
+		for i, it := range x.Items {
+			items[i] = desugarPlus(it)
+		}
+		return NewSequenceNode(items, fuzzLoc)
+	case *OptionalNode:
+		return NewOptionalNode(desugarPlus(x.Expr), fuzzLoc)
+	case *ZeroOrMoreNode:
+		return NewZeroOrMoreNode(desugarPlus(x.Expr), fuzzLoc)
+	case *OneOrMoreNode:
+		e := desugarPlus(x.Expr)
+		return NewSequenceNode([]AstNode{e, NewZeroOrMoreNode(e, fuzzLoc)}, fuzzLoc)
+	case *NotNode:
+		return NewNotNode(desugarPlus(x.Expr), fuzzLoc)
+	case *AndNode:
+		return NewAndNode(desugarPlus(x.Expr), fuzzLoc)
+	case *LexNode:
+		return NewLexNode(desugarPlus(x.Expr), fuzzLoc)
+	default: // atoms
+		return n
+	}
+}
+
+func spellPlusDesugared(g *GrammarNode) string {
+	return desugarPlus(g).(*GrammarNode).String()
+}
+
+// observation is the behaviour of a matcher on one input: whether it accepted
+// and how many bytes it consumed. Two spellings are behaviourally equivalent on
+// an input when their observations agree (consumed is only compared on accept).
+type observation struct {
+	ok       bool
+	consumed int
+}
+
+func (o observation) eq(b observation) bool {
+	return o.ok == b.ok && (!o.ok || o.consumed == b.consumed)
+}
+
+// observeAll runs m over every input under the timeout/panic backstop and
+// returns one observation per input, failing the test on a hang or panic.
+func observeAll(t *testing.T, m Matcher, inputs [][]byte, label, src string) []observation {
+	t.Helper()
+	obs := make([]observation, len(inputs))
+	for i, in := range inputs {
+		res, done := runMatch(m, in, 2*time.Second)
+		require.Truef(t, done, "%s: Match did not terminate\ngrammar:\n%s\ninput: %q", label, src, in)
+		require.Nilf(t, res.panicked, "%s: Match panicked: %v\ngrammar:\n%s\ninput: %q", label, res.panicked, src, in)
+		obs[i] = observation{ok: res.err == nil, consumed: res.consumed}
+	}
+	return obs
+}
+
+func TestSpellingEquivalenceFuzz(t *testing.T) {
+	seed := fuzzEnvInt("LANGLANG_FUZZ_SEED", 1)
+	cases := fuzzEnvInt("LANGLANG_FUZZ_CASES", 200)
+	maxDefs := fuzzEnvInt("LANGLANG_FUZZ_MAXDEFS", 4)
+	depth := fuzzEnvInt("LANGLANG_FUZZ_DEPTH", 4)
+
+	rng := rand.New(rand.NewSource(int64(seed)))
+	var changed, xpass, xfail int
+	for c := 0; c < cases; c++ {
+		t.Run(fmt.Sprintf("case-%d", c), func(t *testing.T) {
+			g := &shapeGen{rng: rng, numDefs: 1 + rng.Intn(maxDefs), execSafe: true}
+			grammar := g.genGrammar(depth)
+			canonical := grammar.String()
+
+			base, err := MatcherFromString(canonical)
+			if err != nil {
+				t.Logf("canonical did not compile (skipping) for:\n%s\nerr: %v", canonical, err)
+				return
+			}
+			inputs := g.inputsFor(grammar, 6)
+			ref := observeAll(t, base, inputs, "canonical", canonical)
+
+			for _, sp := range grammarSpellings {
+				src := sp.spell(grammar)
+				if src == canonical {
+					continue // no-op rewrite: nothing new to compare
+				}
+				changed++
+
+				m, err := MatcherFromString(src)
+				if err != nil {
+					if sp.hard {
+						t.Fatalf("hard spelling %q failed to compile though canonical did\ncanonical:\n%s\n%s:\n%s\nerr: %v", sp.name, canonical, sp.name, src, err)
+					}
+					xfail++
+					t.Logf("%s: xfail — re-spelled grammar did not compile: %v\n%s", sp.name, err, src)
+					continue
+				}
+
+				got := observeAll(t, m, inputs, sp.name, src)
+				agree := true
+				for i := range inputs {
+					if !ref[i].eq(got[i]) {
+						agree = false
+						if sp.hard {
+							t.Fatalf("hard spelling %q disagrees with canonical on input %q\ncanonical (ok=%v n=%d):\n%s\n%s (ok=%v n=%d):\n%s",
+								sp.name, inputs[i], ref[i].ok, ref[i].consumed, canonical, sp.name, got[i].ok, got[i].consumed, src)
+						}
+					}
+				}
+				if !sp.hard {
+					if agree {
+						xpass++
+					} else {
+						xfail++
+						t.Logf("%s: xfail — alternative spelling diverges from canonical\ncanonical:\n%s\n%s:\n%s", sp.name, canonical, sp.name, src)
+					}
+				}
+			}
+		})
+	}
+	t.Logf("spelling fuzz: %d re-spellings exercised (soft variants: %d xpass, %d xfail)", changed, xpass, xfail)
+	require.Positivef(t, changed, "no spelling rewrote the canonical grammar across %d cases — the fuzzer compared nothing", cases)
+}

--- a/justfile
+++ b/justfile
@@ -13,6 +13,20 @@ test: test-go
 test-go: generate
   cd go && go test -v ./...
 
+# Run the generative grammar round-trip fuzzer (parse(g.String()) == g) with a
+# fixed seed and a small case count, for quick iteration. See
+# go/roundtrip_gen_test.go.
+fuzz seed="1" cases="50":
+  cd go && LANGLANG_FUZZ_SEED={{seed}} LANGLANG_FUZZ_CASES={{cases}} go test -v -run TestRoundTripFuzz .
+
+# Sweep the round-trip fuzzer across n random seeds (300 cases each) to widen
+# coverage beyond the deterministic CI seed.
+fuzz-sweep n="12":
+  cd go && for s in $(seq 1 {{n}}); do \
+    echo "seed $s"; \
+    LANGLANG_FUZZ_SEED=$s LANGLANG_FUZZ_CASES=300 go test -run TestRoundTripFuzz . || exit 1; \
+  done
+
 clean: clean-go
 
 clean-go-cache:

--- a/justfile
+++ b/justfile
@@ -13,18 +13,19 @@ test: test-go
 test-go: generate
   cd go && go test -v ./...
 
-# Run the generative grammar round-trip fuzzer (parse(g.String()) == g) with a
-# fixed seed and a small case count, for quick iteration. See
-# go/roundtrip_gen_test.go.
+# Run the generative grammar fuzzers with a fixed seed and a small case count,
+# for quick iteration: the round-trip property (parse(g.String()) == g) and the
+# compile-and-run robustness property. See go/roundtrip_gen_test.go and
+# go/compile_run_fuzz_test.go.
 fuzz seed="1" cases="50":
-  cd go && LANGLANG_FUZZ_SEED={{seed}} LANGLANG_FUZZ_CASES={{cases}} go test -v -run TestRoundTripFuzz .
+  cd go && LANGLANG_FUZZ_SEED={{seed}} LANGLANG_FUZZ_CASES={{cases}} go test -v -run Fuzz .
 
-# Sweep the round-trip fuzzer across n random seeds (300 cases each) to widen
-# coverage beyond the deterministic CI seed.
+# Sweep the fuzzers across n random seeds (300 cases each) to widen coverage
+# beyond the deterministic CI seed.
 fuzz-sweep n="12":
   cd go && for s in $(seq 1 {{n}}); do \
     echo "seed $s"; \
-    LANGLANG_FUZZ_SEED=$s LANGLANG_FUZZ_CASES=300 go test -run TestRoundTripFuzz . || exit 1; \
+    LANGLANG_FUZZ_SEED=$s LANGLANG_FUZZ_CASES=300 go test -run Fuzz . || exit 1; \
   done
 
 clean: clean-go


### PR DESCRIPTION
Add four complementary generative fuzzers that exercise the langlang PEG parser and VM across randomly generated grammars, adapting the algebraic fuzzing approach from the tommy project.

## Summary

These fuzzers form a testing pyramid that validates the grammar pipeline end-to-end:
1. **Round-trip fuzzer** (`roundtrip_gen_test.go`): Verifies the AST printer and parser are consistent — `parse(grammar.String()) == grammar`
2. **Compile-and-run fuzzer** (`compile_run_fuzz_test.go`): Ensures the compiler and VM are robust — generated grammars compile and execute without panics or hangs
3. **Spelling-equivalence fuzzer** (`spelling_fuzz_test.go`): Validates semantic equivalence across alternative surface spellings (parenthesized grouping, plus desugaring)
4. **Matching-input fuzzer** (`matching_input_fuzz_test.go`): Co-generates strings guaranteed to be in the grammar's language and verifies they match

## Key Changes

- **Grammar generation** (`shapeGen` in `roundtrip_gen_test.go`): Generates random legal PEG ASTs over the expression algebra (Choice/Sequence, prefix/suffix operators, atoms). Supports `execSafe` mode to ensure acyclic rule graphs and non-nullable repetition bodies, preventing infinite loops.

- **Execution safety**: The `execSafe`, `noRepetition`, and `noPredicate` flags progressively restrict generation to subsets that are safe to execute or co-generate matching inputs for, with detailed comments explaining the hazards avoided.

- **Spelling variants**: Implements parenthesized grouping and plus-desugaring rewrites to test that semantically equivalent grammars behave identically on the same inputs.

- **Input generation** (`inputsFor`): Biases test inputs toward characters and literals mentioned in the grammar to increase match likelihood.

- **Timeout and panic safety**: All VM executions run under a 2-second timeout and panic recovery to catch hangs and crashes as test failures with reproducers.

- **Deterministic CI**: All fuzzers use fixed seeds (configurable via `LANGLANG_FUZZ_SEED`, `LANGLANG_FUZZ_CASES`, etc.) so CI runs identical test cases every time and failures reproduce locally.

- **Justfile targets**: Added `fuzz` and `fuzz-sweep` recipes for quick iteration and broader seed coverage during development.

## Implementation Details

- The generator respects PEG operator precedence (Choice > Sequence > Prefix > Suffix > Primary) so the unparenthesized printer output is unambiguous.
- Character classes are generated as ranges (never bare chars) to ensure they round-trip through the parser cleanly.
- The matching-input fuzzer restricts to star-free, predicate-free grammars where every construct consumes a bounded, known amount, making co-generation sound.
- Soft failures (xfail) are logged for the plus-desugaring variant, which can lose grouping when desugared sequences are rendered without parentheses.

https://claude.ai/code/session_012qdHgFcRMAwW4Z54F9knVm